### PR TITLE
Prototype for Drag-Based Widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ $tf/
 *.gpState
 
 # ReSharper is a .NET coding add-in
+.idea
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user

--- a/RotationAnarchy/Components/GizmoController.cs
+++ b/RotationAnarchy/Components/GizmoController.cs
@@ -9,6 +9,7 @@
     {
         PlacementModeGizmo placementRotationGizmo;
         TranslationGizmo translationGizmo;
+        private TrackballModeGizmo _trackballModeGizmo;
 
         private List<AbstractGizmo> gizmos = new List<AbstractGizmo>();
 
@@ -20,6 +21,9 @@
 
             translationGizmo = new TranslationGizmo();
             gizmos.Add(translationGizmo);
+
+            _trackballModeGizmo = new TrackballModeGizmo();
+            gizmos.Add(_trackballModeGizmo);
         }
 
         public override void OnUpdate()
@@ -29,9 +33,9 @@
             if (!Camera.main) // Gizmos are dependent on camera
                 return;
 
-            for (int i = 0; i < gizmos.Count; i++)
+            foreach (var gizmo in gizmos)
             {
-                gizmos[i].Update();
+                gizmo.Update();
             }
 
             //if (Input.GetKeyDown(KeyCode.Space))
@@ -81,12 +85,14 @@
 
         public override void OnReverted()
         {
-            for (int i = gizmos.Count - 1; i >= 0; i--)
+            foreach (var gizmo in gizmos)
             {
-                gizmos[i].Destroy();
+                gizmo.Destroy();
             }
             gizmos.Clear();
             placementRotationGizmo = null;
+            translationGizmo = null;
+            _trackballModeGizmo = null;
         }
     }
 

--- a/RotationAnarchy/Components/GizmoController.cs
+++ b/RotationAnarchy/Components/GizmoController.cs
@@ -7,8 +7,8 @@
 
     public class GizmoController : ModComponent
     {
-        PlacementModeGizmo placementRotationGizmo;
-        TranslationGizmo translationGizmo;
+        private PlacementModeGizmo placementRotationGizmo;
+        private TranslationGizmo translationGizmo;
         private TrackballModeGizmo _trackballModeGizmo;
 
         private List<AbstractGizmo> gizmos = new List<AbstractGizmo>();

--- a/RotationAnarchy/Components/Gizmos/AbstractGizmo.cs
+++ b/RotationAnarchy/Components/Gizmos/AbstractGizmo.cs
@@ -18,11 +18,9 @@
             get => _axis;
             set
             {
-                if (_axis != value)
-                {
-                    _axis = value;
-                    OnAxisChanged();
-                }
+                if (_axis == value) return;
+                _axis = value;
+                OnAxisChanged();
             }
         }
 
@@ -71,21 +69,31 @@
 
             if (target != null)
             {
-                // we are going to do a funny hack here
-                var originalRotation = target.transform.rotation;
-                target.transform.rotation = Quaternion.identity;
-                TargetBounds = GameObjectUtil.ComputeTotalBounds(target);
-                target.transform.rotation = originalRotation;
+                TargetBounds = GetBoundsFromTarget(target);
             }
-
-            float xWidth = TargetBounds.max.x - TargetBounds.min.x;
-            float zWidth = TargetBounds.max.z - TargetBounds.min.z;
-            BoundsMax = Mathf.Max(xWidth, zWidth);
+            BoundsMax = GetMaxBoundsFromBounds(TargetBounds);
 
             foreach (var component in gizmoComponents)
             {
                 component.Update();
             }
+        }
+
+        protected virtual Bounds GetBoundsFromTarget(GameObject target)
+        {
+            // we are going to do a funny hack here
+            var originalRotation = target.transform.rotation;
+            target.transform.rotation = Quaternion.identity;
+            var bounds = GameObjectUtil.ComputeTotalBounds(target);
+            target.transform.rotation = originalRotation;
+            return bounds;
+        }
+
+        protected virtual float GetMaxBoundsFromBounds(Bounds bounds)
+        {
+            var xWidth = bounds.max.x - bounds.min.x;
+            var zWidth = bounds.max.z - bounds.min.z;
+            return Mathf.Max(xWidth, zWidth);
         }
 
         public virtual void SnapTo(Vector3 position, Quaternion rotation)
@@ -106,11 +114,9 @@
 
         public virtual void SnapToActiveGhost()
         {
-            if (RA.Controller.ActiveGhost)
-            {
-                var tr = RA.Controller.ActiveGhost.transform;
-                SnapTo(tr.position, tr.rotation);
-            }
+            if (!RA.Controller.ActiveGhost) return;
+            var tr = RA.Controller.ActiveGhost.transform;
+            SnapTo(tr.position, tr.rotation);
         }
 
         public virtual void SnapToSelectedBuildable()

--- a/RotationAnarchy/Components/Gizmos/GizmoComponents/TorusGizmoComponent.cs
+++ b/RotationAnarchy/Components/Gizmos/GizmoComponents/TorusGizmoComponent.cs
@@ -1,23 +1,31 @@
-﻿namespace RotationAnarchy
+﻿using UnityEngine;
+
+namespace RotationAnarchy
 {
-    using RotationAnarchy.Internal.Utils.Meshes;
-    using System;
-    using System.Collections.Generic;
+    using Internal.Utils.Meshes;
 
     public class TorusGizmoComponent : AbstractRenderedMeshGizmoComponent
     {
         public TorusMesh Torus { get; private set; }
+        public MeshCollider MeshCollider { get; private set; }
 
         public TorusGizmoComponent(string name = null) : base(name)
         {
             Torus = new TorusMesh();
             meshFilter.mesh = Torus.mesh;
+            MeshCollider = gameObject.AddComponent<MeshCollider>();
+            if (name != null)
+            {
+                MeshCollider.name = name;
+            }
+            MeshCollider.sharedMesh = Torus.mesh;
         }
 
         public override void Update()
         {
             base.Update();
             Torus.UpdateMesh();
+            MeshCollider.sharedMesh = Torus.mesh;
         }
     }
 }

--- a/RotationAnarchy/Components/Gizmos/PlacementModeGizmo.cs
+++ b/RotationAnarchy/Components/Gizmos/PlacementModeGizmo.cs
@@ -130,6 +130,7 @@
                     // now we need to update gizmo dimensions to the size of the object
                     float torusDiameterFromBounds = BoundsMax + (tubeRadius * 2 + 0.5f);
 
+                    // Do the torus stuff
                     visualTorus1.Torus.TubeRadius = tubeRadius;
                     visualTorus1.Torus.Radius = torusDiameterFromBounds / 2f;
                     visualTorus2.Torus.TubeRadius = tubeRadius;

--- a/RotationAnarchy/Components/Gizmos/TrackballModeGizmo.cs
+++ b/RotationAnarchy/Components/Gizmos/TrackballModeGizmo.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using RotationAnarchy.Internal.Utils;
+
+namespace RotationAnarchy
+{
+    using Internal;
+    using UnityEngine;
+
+    public class TrackballModeGizmo : AbstractRenderedMeshGizmo
+    {
+        public const string TorusXName = "Torus X";
+        public const string TorusYName = "Torus Y";
+        public const string TorusZName = "Torus Z";
+
+        private GizmoComponentGroup _groupTorus;
+        private TorusGizmoComponent _visualTorusX;
+        private TorusGizmoComponent _visualTorusY;
+        private TorusGizmoComponent _visualTorusZ;
+
+        private readonly GizmoOffsets _gizmoOffsets = new GizmoOffsets
+        {
+            X = new GizmoOffsetsBlock
+            {
+                positionOffset = new Vector3(0, 0, 0),
+                rotationOffset = Quaternion.LookRotation(Vector3.right) * Quaternion.LookRotation(Vector3.down)
+            },
+            Y = new GizmoOffsetsBlock
+                {positionOffset = new Vector3(0, 0, 0), rotationOffset = Quaternion.LookRotation(Vector3.forward)},
+            Z = new GizmoOffsetsBlock
+                {positionOffset = new Vector3(0, 0, 0), rotationOffset = Quaternion.LookRotation(Vector3.down)},
+        };
+
+        public TrackballModeGizmo() : base("Placement Mode Gizmo")
+        {
+        }
+
+        protected override void OnConstruct()
+        {
+            base.OnConstruct();
+
+            // Toruses
+            AddGizmoComponent(_groupTorus = new GizmoComponentGroup("VisualGroupTorus"));
+
+            AddGizmoComponent(_visualTorusX = new TorusGizmoComponent(TorusXName));
+            _visualTorusX.Torus.ForwardZ = false;
+            _visualTorusX.Torus.Arc = 360;
+            _visualTorusX.Torus.Taper = false;
+            _visualTorusX.transformInterpolator.TargetRotationOffset = _gizmoOffsets.X.rotationOffset;
+            _visualTorusX.colorInterpolator.TargetColor = GetColorsForAxis(Axis.X).color;
+            _visualTorusX.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.X).outlineColor;
+            _groupTorus.AttachComponent(_visualTorusX);
+
+            AddGizmoComponent(_visualTorusY = new TorusGizmoComponent(TorusYName));
+            _visualTorusY.Torus.ForwardZ = false;
+            _visualTorusY.Torus.Arc = 360;
+            _visualTorusY.Torus.Taper = false;
+            _visualTorusY.transformInterpolator.TargetRotationOffset = _gizmoOffsets.Y.rotationOffset;
+            _visualTorusY.colorInterpolator.TargetColor = GetColorsForAxis(Axis.Y).color;
+            _visualTorusY.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.Y).outlineColor;
+            _groupTorus.AttachComponent(_visualTorusY);
+
+            AddGizmoComponent(_visualTorusZ = new TorusGizmoComponent(TorusZName));
+            _visualTorusZ.Torus.ForwardZ = false;
+            _visualTorusZ.Torus.Arc = 360;
+            _visualTorusZ.Torus.Taper = false;
+            _visualTorusZ.transformInterpolator.TargetRotationOffset = _gizmoOffsets.Z.rotationOffset;
+            _visualTorusZ.colorInterpolator.TargetColor = GetColorsForAxis(Axis.Z).color;
+            _visualTorusZ.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.Z).outlineColor;
+            _groupTorus.AttachComponent(_visualTorusZ);
+        }
+
+        private static GizmoAxisColorBlock GetColorsForAxis(Axis axis)
+        {
+            var colorBlock = RA.GizmoColors.GetForAxis(axis);
+            if (RA.TrackballController.SelectedAxis == axis)
+                return colorBlock;
+            return new GizmoAxisColorBlock
+            {
+                color = colorBlock.color.Scale(0.3f),
+                outlineColor = colorBlock.outlineColor.Scale(0.3f)
+            };
+        }
+
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+
+            if (RA.Controller.ActiveBuilder)
+            {
+                var deco = RA.Controller.ActiveBuilder.getBuiltObject() as Deco;
+                if (deco)
+                {
+                    DebugGUI.DrawValue("orientToSurfaceNormal", deco.orientToSurfaceNormal);
+                    DebugGUI.DrawValue("axisToOrientAlongSurfaceNormal", deco.axisToOrientAlongSurfaceNormal);
+                    DebugGUI.DrawValue("stickToAnySurface", deco.stickToAnySurface);
+                    DebugGUI.DrawValue("stickToHorizontalSurfaces", deco.stickToHorizontalSurfaces);
+                    DebugGUI.DrawValue("stickToSurfaceForwardOffset", deco.stickToSurfaceForwardOffset);
+                    DebugGUI.DrawValue("stickToVerticalSurfaces", deco.stickToVerticalSurfaces);
+                    DebugGUI.DrawValue("stickToTerrain", deco.stickToTerrain);
+                    DebugGUI.DrawValue("snapToDefaultHeightWhenStickingToSurface",
+                        deco.snapToDefaultHeightWhenStickingToSurface);
+
+                    if (deco.orientToSurfaceNormal)
+                        return;
+                }
+            }
+
+            if (RA.Controller.Active && RA.Controller.GameState == ParkitectState.Trackball &&
+                RA.Controller.ActiveGhost)
+            {
+                Active = true;
+                SnapToActiveGhost();
+
+                Axis = RA.Controller.CurrentRotationAxis;
+
+                var offsets = _gizmoOffsets.GetForAxis(Axis);
+                DebugGUI.DrawValue("Current Placement Gizmo Axis", Axis);
+                DebugGUI.DrawValue("Current Placement Gizmo offsetPos", offsets.positionOffset);
+                DebugGUI.DrawValue("Current Placement Gizmo offsetRot", offsets.rotationOffset);
+
+
+                // first we need total bounds of the object
+                if (!RA.Controller.ActiveGhost) return;
+                var ghost = RA.Controller.ActiveGhost;
+
+                var tubeRadius = ComputeGizmoWidth(ghost.transform.position);
+
+                // now we need to update gizmo dimensions to the size of the object
+                var torusDiameterFromBounds = BoundsMax + (tubeRadius * 2 + 0.5f);
+
+
+                _visualTorusX.Torus.TubeRadius = tubeRadius;
+                _visualTorusX.Torus.Radius = torusDiameterFromBounds;
+                _visualTorusY.Torus.TubeRadius = tubeRadius;
+                _visualTorusY.Torus.Radius = torusDiameterFromBounds;
+                _visualTorusZ.Torus.TubeRadius = tubeRadius;
+                _visualTorusZ.Torus.Radius = torusDiameterFromBounds;
+                
+                _visualTorusX.colorInterpolator.TargetColor = GetColorsForAxis(Axis.X).color;
+                _visualTorusX.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.X).outlineColor;
+                _visualTorusY.colorInterpolator.TargetColor = GetColorsForAxis(Axis.Y).color;
+                _visualTorusY.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.Y).outlineColor;
+                _visualTorusZ.colorInterpolator.TargetColor = GetColorsForAxis(Axis.Z).color;
+                _visualTorusZ.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.Z).outlineColor;
+
+                var scale = RA.Controller.HoldingChangeHeightKey ? 1.0f : -1.0f;
+                var t = _groupTorus.transformInterpolator.transform;
+                t.localScale = new Vector3(t.localScale.x, t.localScale.y, scale);
+            }
+            else
+            {
+                Active = false;
+            }
+        }
+
+        protected override float GetMaxBoundsFromBounds(Bounds bounds) =>
+            bounds.extents.magnitude;
+    }
+}

--- a/RotationAnarchy/Components/Gizmos/TrackballModeGizmo.cs
+++ b/RotationAnarchy/Components/Gizmos/TrackballModeGizmo.cs
@@ -30,7 +30,7 @@ namespace RotationAnarchy
                 {positionOffset = new Vector3(0, 0, 0), rotationOffset = Quaternion.LookRotation(Vector3.down)},
         };
 
-        public TrackballModeGizmo() : base("Placement Mode Gizmo")
+        public TrackballModeGizmo() : base(nameof(TrackballModeGizmo))
         {
         }
 
@@ -114,9 +114,9 @@ namespace RotationAnarchy
                 Axis = RA.Controller.CurrentRotationAxis;
 
                 var offsets = _gizmoOffsets.GetForAxis(Axis);
-                DebugGUI.DrawValue("Current Placement Gizmo Axis", Axis);
-                DebugGUI.DrawValue("Current Placement Gizmo offsetPos", offsets.positionOffset);
-                DebugGUI.DrawValue("Current Placement Gizmo offsetRot", offsets.rotationOffset);
+                DebugGUI.DrawValue("Current Trackball Gizmo Axis", Axis);
+                DebugGUI.DrawValue("Current Trackball Gizmo offsetPos", offsets.positionOffset);
+                DebugGUI.DrawValue("Current Trackball Gizmo offsetRot", offsets.rotationOffset);
 
 
                 // first we need total bounds of the object
@@ -143,7 +143,7 @@ namespace RotationAnarchy
                 _visualTorusZ.colorInterpolator.TargetColor = GetColorsForAxis(Axis.Z).color;
                 _visualTorusZ.colorInterpolator.TargetOutlineColor = GetColorsForAxis(Axis.Z).outlineColor;
 
-                var scale = RA.Controller.HoldingChangeHeightKey ? 1.0f : -1.0f;
+                const float scale = 1.0f;
                 var t = _groupTorus.transformInterpolator.transform;
                 t.localScale = new Vector3(t.localScale.x, t.localScale.y, scale);
             }

--- a/RotationAnarchy/Components/RAWorldSpaceUI.cs
+++ b/RotationAnarchy/Components/RAWorldSpaceUI.cs
@@ -67,8 +67,9 @@ namespace RotationAnarchy
 
                 var rotationSpaceText = RA.Controller.IsLocalRotation ? "Local" : "Global";
                 var axesText = GetAxisText();
+                var angleText = GetAngleText();
 
-                LocalSpaceText.text.text = rotationSpaceText + "\n" + axesText;
+                LocalSpaceText.text.text = $"{rotationSpaceText}\n{axesText}\n{angleText}";
                 LocalSpaceText.text.alignment = TextAlignmentOptions.TopLeft;
 
                 LocalSpaceText.gameObject.SetActive(true);
@@ -77,6 +78,21 @@ namespace RotationAnarchy
             else
             {
                 LocalSpaceText.gameObject.SetActive(false);
+            }
+        }
+
+        private static string GetAngleText()
+        {
+            switch (RA.Controller.GameState)
+            {
+                case ParkitectState.Trackball when RA.TrackballController.AngleAmount != null:
+                    return $"{RA.TrackballController.AngleAmount:0.00}°";
+                case ParkitectState.Trackball:
+                case ParkitectState.None:
+                case ParkitectState.Placement:
+                    return "";
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
 

--- a/RotationAnarchy/Components/RAWorldSpaceUI.cs
+++ b/RotationAnarchy/Components/RAWorldSpaceUI.cs
@@ -1,4 +1,6 @@
-﻿namespace RotationAnarchy 
+﻿using System;
+
+namespace RotationAnarchy 
 {
 
     using UnityEngine;
@@ -20,7 +22,7 @@
         };
 
         // Named in order of X, Y, Z
-        public static string[] directionAxesNames = new string[]
+        private static string[] directionAxesNames = new string[]
 {
             "Pitch",    // X
             "Yaw",      // Y
@@ -42,7 +44,7 @@
 
         public override void OnUpdate()
         {
-            if (RA.Controller.ActiveGhost && RA.Controller.ActiveBuilder && RA.Controller.GameState == ParkitectState.Placement)
+            if (RA.Controller.ActiveGhost && RA.Controller.ActiveBuilder && RA.Controller.GameState != ParkitectState.None)
             {
                 var Ghost = RA.Controller.ActiveGhost;
 
@@ -63,8 +65,8 @@
 
                 LocalSpaceText.transform.position = vector - forwardVec * 1.5f;
 
-                string rotationSpaceText = RA.Controller.IsLocalRotation ? "Local" : "Global";
-                string axesText = directionAxesNames[(int)RA.Controller.CurrentRotationAxis];
+                var rotationSpaceText = RA.Controller.IsLocalRotation ? "Local" : "Global";
+                var axesText = GetAxisText();
 
                 LocalSpaceText.text.text = rotationSpaceText + "\n" + axesText;
                 LocalSpaceText.text.alignment = TextAlignmentOptions.TopLeft;
@@ -75,6 +77,23 @@
             else
             {
                 LocalSpaceText.gameObject.SetActive(false);
+            }
+        }
+
+        private static string GetAxisText()
+        {
+            switch (RA.Controller.GameState)
+            {
+                case ParkitectState.None:
+                    return "";
+                case ParkitectState.Placement:
+                    return directionAxesNames[(int)RA.Controller.CurrentRotationAxis];
+                case ParkitectState.Trackball when RA.TrackballController.SelectedAxis != null:
+                    return directionAxesNames[(int)RA.TrackballController.SelectedAxis];
+                case ParkitectState.Trackball when RA.TrackballController.SelectedAxis == null:
+                    return "Free Axis";
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
         }
     }

--- a/RotationAnarchy/Components/TrackballController.cs
+++ b/RotationAnarchy/Components/TrackballController.cs
@@ -44,6 +44,7 @@ namespace RotationAnarchy.Internal
 
             _mouseRay = _camera.ScreenPointToRay(dragStartPos);
 
+            // View axis rotation
             if(RA.Controller.HoldingChangeHeightKey)
             {
                 _viewPlane.Value.Raycast(_mouseRay, out var distance);
@@ -53,6 +54,7 @@ namespace RotationAnarchy.Internal
                     _hemisphereRadius.Value,
                     _mouseRay.GetPoint(distance));
             }
+            // Axis rotation
             else if (SelectedAxis != null && _axisRayPos != null)
             {
                 // Set the axis here to avoid axis shifts towards the "poles" of the gizmo axes

--- a/RotationAnarchy/Components/TrackballController.cs
+++ b/RotationAnarchy/Components/TrackballController.cs
@@ -12,12 +12,10 @@ namespace RotationAnarchy.Internal
         private Plane? _viewPlane;
         private Ray _mouseRay;
         private Camera _camera;
-
-        private Vector3? _axisRayPos;
         private Vector3? _localRotAxis;
+
         public Quaternion Rotation { get; private set; }
         public float? AngleAmount { get; private set; }
-
         public Axis? SelectedAxis { get; private set; }
         public bool AngleSnapActive { get; private set; }
 
@@ -56,19 +54,23 @@ namespace RotationAnarchy.Internal
                     _mouseRay.GetPoint(distance));
             }
             // Axis rotation
-            else if (SelectedAxis != null && _axisRayPos != null)
+            else if (SelectedAxis != null)
             {
                 // Set the axis here to avoid axis shifts towards the "poles" of the gizmo axes
                 // Free rotation mode is unaffected as the rotation cannot exceed a hemisphere
                 _localRotAxis = RA.Controller.IsLocalRotation
                     ? Rotation * GetAxisVector(SelectedAxis.Value)
                     : GetAxisVector(SelectedAxis.Value);
+
+                var axisPlane = new Plane(_localRotAxis.Value, ghostPos);
+                axisPlane.Raycast(_mouseRay, out var distance);
+                var planeIntersect = _mouseRay.GetPoint(distance);
                 
                 _dragStart = ClosestPointForAxis(
                     ghostPos,
                     _localRotAxis.Value,
                     _hemisphereRadius.Value,
-                    _axisRayPos.Value
+                    planeIntersect
                     );
             }
         }
@@ -175,11 +177,6 @@ namespace RotationAnarchy.Internal
                 case TrackballModeGizmo.TorusZName:
                     SelectedAxis = Axis.Z;
                     break;
-            }
-
-            if (SelectedAxis != null)
-            {
-                _axisRayPos = _mouseRay.GetPoint(hitInfo.distance);
             }
         }
 

--- a/RotationAnarchy/Components/TrackballController.cs
+++ b/RotationAnarchy/Components/TrackballController.cs
@@ -210,12 +210,9 @@ namespace RotationAnarchy.Internal
             var distance = Vector3.Dot(offsetFromCenter, axisNormal);
             var projected = position - distance * axisNormal;
 
-            Debug.Log(
-                $"Closest from {position} in plane {projected} at distance {Vector3.Distance(position, projected)}");
-
+            RA.Instance.LOG($"Closest from {position} in plane {projected} at distance {Vector3.Distance(position, projected)}");
             var circlePosition = ClosestPointWithinDistance(center, radius, projected);
-
-            Debug.Log($"Snapped onto circle at {circlePosition}");
+            RA.Instance.LOG($"Snapped onto circle at {circlePosition}");
             return circlePosition;
         }
 

--- a/RotationAnarchy/Components/TrackballController.cs
+++ b/RotationAnarchy/Components/TrackballController.cs
@@ -19,6 +19,7 @@ namespace RotationAnarchy.Internal
         public float? AngleAmount { get; private set; }
 
         public Axis? SelectedAxis { get; private set; }
+        public bool AngleSnapActive { get; private set; }
 
 
         public void Reset()
@@ -95,7 +96,7 @@ namespace RotationAnarchy.Internal
                 var currentVec = closestOnAxis - ghostPos;
                 
                 AngleAmount = Vector3.SignedAngle(startVec, currentVec, _localRotAxis.Value);
-                if (RA.Controller.AngleSnapActive)
+                if (AngleSnapActive)
                     AngleAmount = AngleAmount.Value.RoundToMultipleOf(RA.RotationAngle.Value);
                 trackballRotation = Quaternion.AngleAxis(AngleAmount.Value, _localRotAxis.Value);
             }
@@ -115,7 +116,7 @@ namespace RotationAnarchy.Internal
 
                 var rotationAxis = Vector3.Cross(startVec, currentVec).normalized;
                 AngleAmount = Vector3.Angle(startVec, currentVec);
-                if (RA.Controller.AngleSnapActive)
+                if (AngleSnapActive)
                     AngleAmount = AngleAmount.Value.RoundToMultipleOf(RA.RotationAngle.Value);
                 trackballRotation = Quaternion.AngleAxis(AngleAmount.Value, rotationAxis);
             }
@@ -123,10 +124,20 @@ namespace RotationAnarchy.Internal
             Rotation = trackballRotation * _initialRotation.Value;
         }
 
+        #region Keybinds
+
         public override void OnApplied()
         {
-            // TODO: Extract from Update?
+            RA.AngleSnapHotkey.onKeyDown += ToggleAngleSnap;
         }
+
+        private void ToggleAngleSnap()
+        {
+            AngleSnapActive = !AngleSnapActive;
+        }
+
+        #endregion
+
 
         public override void OnReverted()
         {

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -13,6 +13,9 @@ namespace RotationAnarchy.Internal
         private Camera _camera;
 
         public Quaternion Rotation { get; private set; }
+
+        public float? AngleAmount { get; private set; } = null;
+
         public Axis? SelectedAxis { get; private set; }
 
         private Vector3? _axisRayPos;
@@ -86,8 +89,8 @@ namespace RotationAnarchy.Internal
                 var startVec = _dragStart.Value - ghostPos;
                 var currentVec = closestOnAxis - ghostPos;
                 
-                var rotationAngle = Vector3.SignedAngle(startVec, currentVec, axisNormal);
-                trackballRotation = Quaternion.AngleAxis(rotationAngle, axisNormal);
+                AngleAmount = Vector3.SignedAngle(startVec, currentVec, axisNormal);
+                trackballRotation = Quaternion.AngleAxis(AngleAmount.Value, axisNormal);
             }
             else
             {
@@ -104,8 +107,8 @@ namespace RotationAnarchy.Internal
                 var currentVec = currentPos - ghostPos;
 
                 var rotationAxis = Vector3.Cross(startVec, currentVec).normalized;
-                var rotationAngle = Vector3.Angle(startVec, currentVec);
-                trackballRotation = Quaternion.AngleAxis(rotationAngle, rotationAxis);
+                AngleAmount = Vector3.Angle(startVec, currentVec);
+                trackballRotation = Quaternion.AngleAxis(AngleAmount.Value, rotationAxis);
             }
 
             Rotation = trackballRotation * _initialRotation.Value;

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -55,6 +55,8 @@ namespace RotationAnarchy.Internal
             }
             else if (SelectedAxis != null && _axisRayPos != null)
             {
+                // Set the axis here to avoid axis shifts towards the "poles" of the gizmo axes
+                // Free rotation mode is unaffected as the rotation cannot exceed a hemisphere
                 _localRotAxis = RA.Controller.IsLocalRotation
                     ? Rotation * GetAxisVector(SelectedAxis.Value)
                     : GetAxisVector(SelectedAxis.Value);

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -71,7 +71,6 @@ namespace RotationAnarchy.Internal
             Quaternion trackballRotation;
             if (SelectedAxis != null)
             {
-                Debug.Log($"Doing stuff for axis{SelectedAxis}");
                 var axisPlane = new Plane(Rotation * GetAxisVector(SelectedAxis.Value), ghostPos);
                 axisPlane.Raycast(_mouseRay, out var distance);
                 var planeIntersect = _mouseRay.GetPoint(distance);

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -48,9 +48,13 @@ namespace RotationAnarchy.Internal
             }
             else if (SelectedAxis != null && _axisRayPos != null)
             {
+                var normal = RA.Controller.IsLocalRotation
+                    ? Rotation * GetAxisVector(SelectedAxis.Value)
+                    : GetAxisVector(SelectedAxis.Value);
+                    
                 _dragStart = ClosestPointForAxis(
                     ghostPos,
-                    Rotation * GetAxisVector(SelectedAxis.Value),
+                    normal,
                     _hemisphereRadius.Value,
                     _axisRayPos.Value
                     );
@@ -70,7 +74,10 @@ namespace RotationAnarchy.Internal
             Quaternion trackballRotation;
             if (SelectedAxis != null)
             {
-                var axisPlane = new Plane(Rotation * GetAxisVector(SelectedAxis.Value), ghostPos);
+                var axisNormal = RA.Controller.IsLocalRotation
+                    ? Rotation * GetAxisVector(SelectedAxis.Value)
+                    : GetAxisVector(SelectedAxis.Value);   
+                var axisPlane = new Plane(axisNormal, ghostPos);
                 axisPlane.Raycast(_mouseRay, out var distance);
                 var planeIntersect = _mouseRay.GetPoint(distance);
                 var closestOnAxis = ClosestPointWithinDistance(ghostPos, _hemisphereRadius.Value, planeIntersect);
@@ -79,9 +86,8 @@ namespace RotationAnarchy.Internal
                 var startVec = _dragStart.Value - ghostPos;
                 var currentVec = closestOnAxis - ghostPos;
                 
-                var rotationAxis = Rotation * GetAxisVector(SelectedAxis.Value);
-                var rotationAngle = Vector3.SignedAngle(startVec, currentVec, rotationAxis);
-                trackballRotation = Quaternion.AngleAxis(rotationAngle, rotationAxis);
+                var rotationAngle = Vector3.SignedAngle(startVec, currentVec, axisNormal);
+                trackballRotation = Quaternion.AngleAxis(rotationAngle, axisNormal);
             }
             else
             {

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -13,8 +13,7 @@ namespace RotationAnarchy.Internal
         private Camera _camera;
 
         public Quaternion Rotation { get; private set; }
-
-        public float? AngleAmount { get; private set; } = null;
+        public float? AngleAmount { get; private set; }
 
         public Axis? SelectedAxis { get; private set; }
 
@@ -27,6 +26,7 @@ namespace RotationAnarchy.Internal
             _hemisphereRadius = null;
             _camera = null;
             SelectedAxis = null;
+            AngleAmount = null;
         }
 
         public void BeginDrag(Quaternion rotation, float radius, Vector3 dragStartPos)
@@ -37,6 +37,7 @@ namespace RotationAnarchy.Internal
             _viewPlane = new Plane(_camera.transform.forward * -1, ghostPos);
             _initialRotation = rotation;
             _hemisphereRadius = radius;
+            AngleAmount = null;
 
             _mouseRay = _camera.ScreenPointToRay(dragStartPos);
 

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using UnityEngine;
+
+namespace RotationAnarchy.Internal
+{
+    public class TrackballController : ModComponent
+    {
+        private Vector3? _dragStart;
+        private Quaternion? _initialRotation;
+        private float? _hemisphereRadius;
+        private Plane? _viewPlane;
+        private Ray _mouseRay;
+        private Camera _camera;
+
+        public Quaternion Rotation { get; private set; }
+
+        public void Reset()
+        {
+            _dragStart = null;
+            _initialRotation = null;
+            _hemisphereRadius = null;
+            _camera = null;
+        }
+
+        public void Initialize(Quaternion rotation, float radius, Vector3 ghostPos, Vector3 dragStartPos)
+        {
+            _camera = Camera.main;
+            if (_camera == null) throw new InvalidOperationException("Camera was null");
+
+            _viewPlane = new Plane(_camera.transform.forward * -1, ghostPos);
+            _initialRotation = rotation;
+            _hemisphereRadius = radius;
+
+            var mouseRay = _camera.ScreenPointToRay(dragStartPos);
+            _viewPlane.Value.Raycast(_mouseRay, out var distance);
+            _dragStart = SnapToHemisphere(
+                ghostPos,
+                _viewPlane.Value.normal,
+                _hemisphereRadius.Value,
+                mouseRay.GetPoint(distance));
+        }
+
+        public void UpdateState(Vector3 ghostPos, Vector3 dragPos)
+        {
+
+            if (_viewPlane == null) throw new InvalidOperationException($"{nameof(_viewPlane)} was null");
+            if (_hemisphereRadius == null) throw new InvalidOperationException($"{nameof(_hemisphereRadius)} was null");
+            if (_dragStart == null) throw new InvalidOperationException($"{nameof(_dragStart)} was null");
+            if (_initialRotation == null) throw new InvalidOperationException($"{nameof(_initialRotation)} was null");
+
+            _mouseRay = _camera.ScreenPointToRay(dragPos);
+            _viewPlane.Value.Raycast(_mouseRay, out var distance);
+            var currentPos = SnapToHemisphere(
+                ghostPos,
+                _viewPlane.Value.normal,
+                _hemisphereRadius.Value,
+                _mouseRay.GetPoint(distance));
+
+            if (Vector3.Distance(_dragStart.Value, currentPos) <= float.Epsilon) return;
+
+            var startVec = _dragStart.Value - ghostPos;
+            var currentVec = currentPos - ghostPos;
+
+            var rotationAxis = Vector3.Cross(startVec, currentVec).normalized;
+            var rotationAngle = Vector3.Angle(startVec, currentVec);
+            var trackballRotation = Quaternion.AngleAxis(rotationAngle, rotationAxis);
+
+            Rotation = trackballRotation * _initialRotation.Value;
+        }
+
+        public override void OnApplied()
+        {
+            // TODO: Extract from Update?
+        }
+
+        public override void OnReverted()
+        {
+            // TODO: Extract from Update?
+        }
+
+        private static Vector3 SnapToHemisphere(Vector3 center, Vector3 normal, float radius, Vector3 position)
+        {
+            var rotationToFlat = Quaternion.FromToRotation(normal, Vector3.up).normalized;
+            var rotationFromFlat = Quaternion.FromToRotation(Vector3.up, normal).normalized;
+
+            var offsetFromCenter = position - center;
+            var offsetInPlane = rotationToFlat * offsetFromCenter;
+            var unitPosition = offsetInPlane / radius;
+
+            var distanceFromCenter = unitPosition.magnitude;
+            if (distanceFromCenter > 1)
+            {
+                var borderSnapPos = new Vector3(unitPosition.x, 0, unitPosition.z).normalized;
+                return rotationFromFlat * (borderSnapPos * radius) + center;
+            }
+
+            var hemisphereY = (float) Math.Sqrt(1 - Math.Pow(unitPosition.x, 2) - Math.Pow(unitPosition.z, 2));
+            var snapPos = new Vector3(unitPosition.x, hemisphereY, unitPosition.z);
+            return rotationFromFlat * (snapPos * radius) + center;
+        }
+    }
+}

--- a/RotationAnarchy/Internal/TrackballController.cs
+++ b/RotationAnarchy/Internal/TrackballController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using RotationAnarchy.Internal.Utils;
 using UnityEngine;
 
 namespace RotationAnarchy.Internal
@@ -91,6 +92,8 @@ namespace RotationAnarchy.Internal
                 var currentVec = closestOnAxis - ghostPos;
                 
                 AngleAmount = Vector3.SignedAngle(startVec, currentVec, axisNormal);
+                if (RA.Controller.AngleSnapActive)
+                    AngleAmount = AngleAmount.Value.RoundToMultipleOf(RA.RotationAngle.Value);
                 trackballRotation = Quaternion.AngleAxis(AngleAmount.Value, axisNormal);
             }
             else
@@ -109,6 +112,8 @@ namespace RotationAnarchy.Internal
 
                 var rotationAxis = Vector3.Cross(startVec, currentVec).normalized;
                 AngleAmount = Vector3.Angle(startVec, currentVec);
+                if (RA.Controller.AngleSnapActive)
+                    AngleAmount = AngleAmount.Value.RoundToMultipleOf(RA.RotationAngle.Value);
                 trackballRotation = Quaternion.AngleAxis(AngleAmount.Value, rotationAxis);
             }
 

--- a/RotationAnarchy/Internal/Utils/ColorExtensions.cs
+++ b/RotationAnarchy/Internal/Utils/ColorExtensions.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace RotationAnarchy.Internal.Utils
+{
+    public static class ColorExtensions
+    {
+        public static Color Scale(this Color color, float factor) => 
+            new Color(color.r * factor, color.g * factor, color.b * factor, color.a);
+    }
+}

--- a/RotationAnarchy/Internal/Utils/FloatExtensions.cs
+++ b/RotationAnarchy/Internal/Utils/FloatExtensions.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace RotationAnarchy.Internal.Utils
+{
+    public static class FloatExtensions
+    {
+        public static float RoundToMultipleOf(this float number, float value) =>
+            Mathf.Round(number / value) * value;
+    }
+}

--- a/RotationAnarchy/Patches/Patch_Builder_Update.cs
+++ b/RotationAnarchy/Patches/Patch_Builder_Update.cs
@@ -1,22 +1,63 @@
 ﻿using System;
-using System.Linq;
 using UnityEngine;
 using HarmonyLib;
-using Parkitect;
+using RotationAnarchy.Internal;
 
 namespace RotationAnarchy.Patches
 {
     [HarmonyPatch(typeof(Builder), "Update")]
     internal static class Patch_Builder_Update
     {
-        private static bool _previousFrameActive;
+        private static bool previousFrameActive;
+
+        static bool Prefix(ref Quaternion ___rotation, ref Vector3 ___forward, ref GameObject ___ghost, ref bool ___dontAutoRotate)
+        {
+            if (!RA.Controller.Active) return true;
+            if (!RA.Controller.IsDragRotation) return true;
+
+            if (Input.GetMouseButtonUp(0))
+            {
+                ___forward = ___rotation * Vector3.forward;
+                RA.TrackballController.Reset();
+                return false;
+            }
+
+            var camera = Camera.main;
+            if (camera == null) throw new InvalidOperationException("Camera was null");
+            var ghostPos = ___ghost.transform.position;
+
+            if (Input.GetMouseButtonDown(0))
+            {
+                RA.TrackballController.Initialize(
+                    ___rotation,
+                    GameObjectUtil.ComputeTotalBounds(___ghost).extents.magnitude,
+                    ghostPos, Input.mousePosition);
+
+                return false;
+            }
+
+            if (Input.GetMouseButton(0))
+            {
+                RA.TrackballController.UpdateState(ghostPos, Input.mousePosition);
+
+                ___dontAutoRotate = true;
+                ___rotation = RA.TrackballController.Rotation;
+                ___ghost.transform.rotation = RA.TrackballController.Rotation;
+
+                return false;
+            }
+
+            return false;
+        }
+
+        
 
         static void Postfix(ref Quaternion ___rotation, ref Vector3 ___forward, ref GameObject ___ghost)
         {
             // We reset the rotation of the Builder if RA has just deactivated.
             if (!RA.Controller.Active)
             {
-                if(_previousFrameActive)
+                if(previousFrameActive)
                 {
                     ___forward = Vector3.forward;
                     ___rotation = Quaternion.LookRotation(___forward);
@@ -27,7 +68,7 @@ namespace RotationAnarchy.Patches
                 RA.Controller.NotifyGhost(___ghost);
             }
 
-            _previousFrameActive = RA.Controller.Active;
+            previousFrameActive = RA.Controller.Active;
         }
     }
 }

--- a/RotationAnarchy/Patches/Patch_Builder_changeRotation.cs
+++ b/RotationAnarchy/Patches/Patch_Builder_changeRotation.cs
@@ -9,14 +9,15 @@ namespace RotationAnarchy.Patches
         static bool Prefix(Quaternion ___rotation, ref Quaternion __state)
         {
             __state = ___rotation;
-            return !RA.Controller.Active;
+            /// TODO: Backport to future versions
+            return !(RA.Controller.Active && RA.Controller.GameState == ParkitectState.Placement);
         }
 
         static void Postfix(int direction, ref Quaternion ___rotation, Quaternion __state, ref Vector3 ___forward, ref bool ___dontAutoRotate)
         {
 
-            // If the mod is currently active
-            if (RA.Controller.Active)
+            // If the mod is currently active /// TODO: Backport to future versions
+            if (RA.Controller.Active && RA.Controller.GameState == ParkitectState.Placement)
             {
 
                 // True if in local space, otherwise in world space

--- a/RotationAnarchy/RA.cs
+++ b/RotationAnarchy/RA.cs
@@ -73,7 +73,7 @@
             RAActiveHotkey = NewHotkey("active", "Toggle RA", "Toggle Rotation Anarchy active, without disabling it.", KeyCode.Y);
             DirectionHotkey = NewHotkey("direction", "Rotation direction", "Change the rotation axes from horizontal to vertical", KeyCode.LeftControl);
             LocalRotationHotkey = NewHotkey("localSpace", "Local space", "Change the rotation axes from local space (object axes) to global space (world axes)", KeyCode.CapsLock);
-            DragRotationHotkey = NewHotkey("dragRotation", "Drag Rotation", "TODO", KeyCode.Keypad3);
+            DragRotationHotkey = NewHotkey("dragRotation", "Drag Rotation", "Toggle to a Trackball-Style dragging mode, use Height-Change Key to lock Axis", KeyCode.Keypad3);
 
             // Mod changes registration --------------------------------------------------------
             RegisterComponent(Controller = new RAController());

--- a/RotationAnarchy/RA.cs
+++ b/RotationAnarchy/RA.cs
@@ -29,9 +29,11 @@
         public static BaseHotkey RAActiveHotkey { get; private set; }
         public static BaseHotkey DirectionHotkey { get; private set; }
         public static BaseHotkey LocalRotationHotkey { get; private set; }
+        public static BaseHotkey DragRotationHotkey { get; private set; }
 
         // Features    -------------------------------------------------------
         public static RAController Controller { get; private set; }
+        public static TrackballController TrackballController { get; private set; }
 
         // Params      -------------------------------------------------------
         public static Color SelectedBuildableHighlightColor { get; private set; } = new Color32(0, 162, 232, 255);
@@ -71,9 +73,11 @@
             RAActiveHotkey = NewHotkey("active", "Toggle RA", "Toggle Rotation Anarchy active, without disabling it.", KeyCode.Y);
             DirectionHotkey = NewHotkey("direction", "Rotation direction", "Change the rotation axes from horizontal to vertical", KeyCode.LeftControl);
             LocalRotationHotkey = NewHotkey("localSpace", "Local space", "Change the rotation axes from local space (object axes) to global space (world axes)", KeyCode.CapsLock);
+            DragRotationHotkey = NewHotkey("dragRotation", "Drag Rotation", "TODO", KeyCode.Keypad3);
 
             // Mod changes registration --------------------------------------------------------
             RegisterComponent(Controller = new RAController());
+            RegisterComponent(TrackballController = new TrackballController());
             RegisterComponent(new ChangeUIBackgroundGraphics());
             RegisterComponent(new ConstructWindowToggle());
             RegisterComponent(new RADebug());

--- a/RotationAnarchy/RA.cs
+++ b/RotationAnarchy/RA.cs
@@ -30,6 +30,7 @@
         public static BaseHotkey DirectionHotkey { get; private set; }
         public static BaseHotkey LocalRotationHotkey { get; private set; }
         public static BaseHotkey DragRotationHotkey { get; private set; }
+        public static BaseHotkey AngleSnapHotkey { get; private set; }
 
         // Features    -------------------------------------------------------
         public static RAController Controller { get; private set; }
@@ -74,6 +75,7 @@
             DirectionHotkey = NewHotkey("direction", "Rotation direction", "Change the rotation axes from horizontal to vertical", KeyCode.LeftControl);
             LocalRotationHotkey = NewHotkey("localSpace", "Local space", "Change the rotation axes from local space (object axes) to global space (world axes)", KeyCode.CapsLock);
             DragRotationHotkey = NewHotkey("dragRotation", "Drag Rotation", "Toggle to a Trackball-Style dragging mode, use Height-Change Key to lock Axis", KeyCode.Keypad3);
+            AngleSnapHotkey = NewHotkey("angleSnap", "Angle Snapping", "Toggle angle snapping for drag rotation", KeyCode.Keypad1);
 
             // Mod changes registration --------------------------------------------------------
             RegisterComponent(Controller = new RAController());

--- a/RotationAnarchy/RA.cs
+++ b/RotationAnarchy/RA.cs
@@ -1,4 +1,6 @@
-﻿namespace RotationAnarchy
+﻿using RotationAnarchy.Components;
+
+namespace RotationAnarchy
 {
     using UnityEngine;
     using RotationAnarchy.Internal;

--- a/RotationAnarchy/RA.cs
+++ b/RotationAnarchy/RA.cs
@@ -10,7 +10,7 @@
         public override string MODKEY => "rotationAnarchy";
         public override string getName() => "Rotation Anarchy";
         public override string getDescription() => "Adds a more advanced rotation gizmo for Deco and Flatrides.";
-        protected override string SettingsInfoString => "Howdy, pardner.";
+        protected override string SettingsInfoString => "Settings";
         protected override Assembly AssemblyGetter => Assembly.GetExecutingAssembly();
 
         // Prefs values -------------------------------------------------------
@@ -60,7 +60,7 @@
             base.OnModEnabled();
 
             // Version registration      -------------------------------------------------------
-            NewVersion("0.1", "Baseline");
+            NewVersion("1.0", "Phase 1 of Rotation Anarchy");
 
             // Prefs values registration -------------------------------------------------------
             RegisterAndLoadPrefsValue(ActiveOnLoad = new PrefsBool("activeOnLoad", true, "Active On Load"));
@@ -83,8 +83,6 @@
             RegisterComponent(new RADebug());
             RegisterComponent(new GizmoController());
             RegisterComponent(new RAWorldSpaceText());
-
-            DebugGUI.SetActive(true);
         }
 
         protected override void OnModUpdate()

--- a/RotationAnarchy/RAController.cs
+++ b/RotationAnarchy/RAController.cs
@@ -28,7 +28,6 @@
         public float CurrentZoom { get; private set; }
         public bool IsPickingObject { get; private set; }
         public bool GizmoActive { get; private set; }
-        public bool AngleSnapActive { get; private set; }
 
         /// <summary>
         /// Also acts as "invert" rotation direction.
@@ -92,7 +91,6 @@
             RA.DirectionHotkey.onKeyDown += ToggleDirection;
             RA.SelectObjectHotkey.onKeyDown += StartPickingObject;
             RA.DragRotationHotkey.onKeyDown += ToggleDragRotation;
-            RA.AngleSnapHotkey.onKeyDown += ToggleAngleSnap;
         }
 
         public override void OnStart()
@@ -211,11 +209,6 @@
                 default:
                     throw new ArgumentOutOfRangeException(nameof(GameState));
             }
-        }
-        
-        private void ToggleAngleSnap()
-        {
-            AngleSnapActive = !AngleSnapActive;
         }
 
         public void NotifyWindowState(bool opened)

--- a/RotationAnarchy/RAController.cs
+++ b/RotationAnarchy/RAController.cs
@@ -11,6 +11,7 @@
     {
         None,
         Placement,
+        Trackball
     }
 
     public class RAController : ModComponent
@@ -51,8 +52,6 @@
         public bool IsLocalRotation { get; private set; }
 
         public Axis CurrentRotationAxis { get; private set; }
-        
-        public bool IsDragRotation { get; private set; }
 
         public ParkitectState GameState
         {
@@ -188,9 +187,24 @@
             }
         }
 
-        public void ToggleDragRotation()
+        private void ToggleDragRotation()
         {
-            IsDragRotation = !IsDragRotation;
+            switch (GameState)
+            {
+                case ParkitectState.Placement:
+                    IsLocalRotation = true;
+                    GameState = ParkitectState.Trackball;
+                    break;
+                case ParkitectState.Trackball:
+                    IsLocalRotation = false;
+                    GameState = ParkitectState.Placement;
+                    break;
+                case ParkitectState.None:
+                    // NoOp
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(GameState));
+            }
         }
 
         public void NotifyWindowState(bool opened)

--- a/RotationAnarchy/RAController.cs
+++ b/RotationAnarchy/RAController.cs
@@ -51,6 +51,8 @@
         public bool IsLocalRotation { get; private set; }
 
         public Axis CurrentRotationAxis { get; private set; }
+        
+        public bool IsDragRotation { get; private set; }
 
         public ParkitectState GameState
         {
@@ -89,6 +91,7 @@
             RA.LocalRotationHotkey.onKeyDown += ToggleLocalRotationActive;
             RA.DirectionHotkey.onKeyDown += ToggleDirection;
             RA.SelectObjectHotkey.onKeyDown += StartPickingObject;
+            RA.DragRotationHotkey.onKeyDown += ToggleDragRotation;
         }
 
         public override void OnStart()
@@ -183,6 +186,11 @@
 
                     break;
             }
+        }
+
+        public void ToggleDragRotation()
+        {
+            IsDragRotation = !IsDragRotation;
         }
 
         public void NotifyWindowState(bool opened)

--- a/RotationAnarchy/RAController.cs
+++ b/RotationAnarchy/RAController.cs
@@ -96,6 +96,7 @@
         public override void OnStart()
         {
             Active = RA.ActiveOnLoad.Value;
+            CurrentRotationAxis = Axis.Y;
         }
 
         public override void OnReverted() { }
@@ -135,6 +136,11 @@
                     GameState = ParkitectState.None;
                     ModBase.LOG($"Not building  {builder.GetType()} : {builder.name}");
                 }
+            }
+            else
+            {/// TODO: Backport to future versions
+                ActiveBuilder = null;
+                GameState = ParkitectState.None;
             }
         }
 
@@ -256,6 +262,7 @@
 
         private bool ShouldWindowBeOpened()
         {
+            return false;
             return Active || GameState == ParkitectState.Placement;
         }
 

--- a/RotationAnarchy/RAController.cs
+++ b/RotationAnarchy/RAController.cs
@@ -28,6 +28,7 @@
         public float CurrentZoom { get; private set; }
         public bool IsPickingObject { get; private set; }
         public bool GizmoActive { get; private set; }
+        public bool AngleSnapActive { get; private set; }
 
         /// <summary>
         /// Also acts as "invert" rotation direction.
@@ -91,6 +92,7 @@
             RA.DirectionHotkey.onKeyDown += ToggleDirection;
             RA.SelectObjectHotkey.onKeyDown += StartPickingObject;
             RA.DragRotationHotkey.onKeyDown += ToggleDragRotation;
+            RA.AngleSnapHotkey.onKeyDown += ToggleAngleSnap;
         }
 
         public override void OnStart()
@@ -209,6 +211,11 @@
                 default:
                     throw new ArgumentOutOfRangeException(nameof(GameState));
             }
+        }
+        
+        private void ToggleAngleSnap()
+        {
+            AngleSnapActive = !AngleSnapActive;
         }
 
         public void NotifyWindowState(bool opened)

--- a/RotationAnarchy/RAController.cs
+++ b/RotationAnarchy/RAController.cs
@@ -198,11 +198,9 @@
             switch (GameState)
             {
                 case ParkitectState.Placement:
-                    IsLocalRotation = true;
                     GameState = ParkitectState.Trackball;
                     break;
                 case ParkitectState.Trackball:
-                    IsLocalRotation = false;
                     GameState = ParkitectState.Placement;
                     break;
                 case ParkitectState.None:

--- a/RotationAnarchy/RotationAnarchy.csproj
+++ b/RotationAnarchy/RotationAnarchy.csproj
@@ -115,7 +115,7 @@
     <Compile Include="Components\Gizmos\PlacementModeGizmo.cs" />
     <Compile Include="Components\Gizmos\TrackballModeGizmo.cs" />
     <Compile Include="Components\Gizmos\TranslationGizmo.cs" />
-    <Compile Include="Internal\TrackballController.cs" />
+    <Compile Include="Components\TrackballController.cs" />
     <Compile Include="Internal\Utils\ColorExtensions.cs" />
     <Compile Include="Internal\Utils\DebugGUI.cs" />
     <Compile Include="Internal\Utils\FloatExtensions.cs" />

--- a/RotationAnarchy/RotationAnarchy.csproj
+++ b/RotationAnarchy/RotationAnarchy.csproj
@@ -113,8 +113,10 @@
     <Compile Include="Components\Gizmos\GizmoComponents\GizmoComponentGroup.cs" />
     <Compile Include="Components\Gizmos\GizmoComponents\TorusGizmoComponent.cs" />
     <Compile Include="Components\Gizmos\PlacementModeGizmo.cs" />
+    <Compile Include="Components\Gizmos\TrackballModeGizmo.cs" />
     <Compile Include="Components\Gizmos\TranslationGizmo.cs" />
     <Compile Include="Internal\TrackballController.cs" />
+    <Compile Include="Internal\Utils\ColorExtensions.cs" />
     <Compile Include="Internal\Utils\DebugGUI.cs" />
     <Compile Include="Internal\Utils\GameObjectWrapper.cs" />
     <Compile Include="Internal\Utils\TransformInterpolator.cs" />

--- a/RotationAnarchy/RotationAnarchy.csproj
+++ b/RotationAnarchy/RotationAnarchy.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="Parkitect">
       <HintPath>..\Libs\Parkitect.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -51,25 +52,32 @@
     <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\Unity.TextMeshPro.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\Libs\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
       <HintPath>..\Libs\UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
       <HintPath>..\Libs\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libs\UnityEngine.InputLegacyModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
       <HintPath>..\Libs\UnityEngine.InputModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -78,15 +86,19 @@
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libs\UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>..\Libs\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
       <HintPath>..\Libs\UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -102,6 +114,7 @@
     <Compile Include="Components\Gizmos\GizmoComponents\TorusGizmoComponent.cs" />
     <Compile Include="Components\Gizmos\PlacementModeGizmo.cs" />
     <Compile Include="Components\Gizmos\TranslationGizmo.cs" />
+    <Compile Include="Internal\TrackballController.cs" />
     <Compile Include="Internal\Utils\DebugGUI.cs" />
     <Compile Include="Internal\Utils\GameObjectWrapper.cs" />
     <Compile Include="Internal\Utils\TransformInterpolator.cs" />

--- a/RotationAnarchy/RotationAnarchy.csproj
+++ b/RotationAnarchy/RotationAnarchy.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Internal\TrackballController.cs" />
     <Compile Include="Internal\Utils\ColorExtensions.cs" />
     <Compile Include="Internal\Utils\DebugGUI.cs" />
+    <Compile Include="Internal\Utils\FloatExtensions.cs" />
     <Compile Include="Internal\Utils\GameObjectWrapper.cs" />
     <Compile Include="Internal\Utils\TransformInterpolator.cs" />
     <Compile Include="Components\RADebug.cs" />


### PR DESCRIPTION
- [x] Fix weird spazzing motion when approaching very broad angles in local rotation near the "ends" of the axes perpendicular to the view direction
This also seems to completely bypass the angle snapping
Probably needs an epsilon check for axis plane distance
- [x] Degree display for current drag motion in WorldSpaceUI (should be made relative to drag rotation later to avoid negatives)
- [x] Snapped axis name in WorldSpaceUI
- [x] Angle snapping? (probably later)